### PR TITLE
switch to orm model

### DIFF
--- a/billing/models/Subscription.py
+++ b/billing/models/Subscription.py
@@ -1,5 +1,4 @@
-from config.database import Model
-
+from masoniteorm.models import Model
 
 class Subscription(Model):
     __fillable__ = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-dotenv
-orator
-masonite>=2.2
+masonite-orm
+masonite>=3.0
 stripe
 flake8
 pytest


### PR DESCRIPTION
Update to use new Masonite ORM instead of Orator

Requires this PR - https://github.com/MasoniteFramework/orm/pull/484 - since we use Pendulum for dates.